### PR TITLE
Provide DEP_URING_INCLUDE directory for other crates

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,6 @@ fn main() {
         .file(src.join("syscall.c"))
         .file(src.join("register.c"))
         .define("_DEFAULT_SOURCE", "")
-        .include(src.join("include"))
         .include(&configured_include)
         .extra_warnings(false)
         .compile("uring");
@@ -31,17 +30,21 @@ fn main() {
     // (our additional, linkable C bindings)
     Build::new()
         .file(project.join("rusturing.c"))
-        .include(src.join("include"))
         .include(&configured_include)
         .compile("rusturing");
+
+    println!("cargo:include={}", configured_include.display());
 }
 
 fn configure(liburing: &Path) -> PathBuf {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap())
         .canonicalize()
         .unwrap();
-    fs::copy(liburing.join("configure"), out_dir.join("configure")).unwrap();
     fs::create_dir_all(out_dir.join("src/include/liburing")).unwrap();
+    fs::copy(liburing.join("configure"), out_dir.join("configure")).unwrap();
+    fs::copy(liburing.join("src/include/liburing.h"), out_dir.join("src/include/liburing.h")).unwrap();
+    fs::copy(liburing.join("src/include/liburing/barrier.h"), out_dir.join("src/include/liburing/barrier.h")).unwrap();
+    fs::copy(liburing.join("src/include/liburing/io_uring.h"), out_dir.join("src/include/liburing/io_uring.h")).unwrap();
     Command::new("./configure")
         .current_dir(&out_dir)
         .output()


### PR DESCRIPTION
So that other crates with C libs that depend on liburing can take advantage of the bundled headers.

Rationale for copying headers around is to provide a single include directory.

---

Forwarded from https://github.com/ringbahn/uring-sys/pull/30, because `ringbahn/uring-sys` appears to be unmaintained.